### PR TITLE
Make plugin work again on latest vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,7 @@
 {
 	"version": "0.1.0",
 	"configurations": [
+		
 		{
 			"name": "Launch Extension",
 			"type": "extensionHost",
@@ -10,7 +11,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/src",
+            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +22,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/test",
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
 			"preLaunchTask": "npm"
 		}
 	]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,23 +8,23 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-	"version": "0.1.0",
+    "version": "0.1.0",
 
-	// we want to run npm
-	"command": "npm",
+    // we want to run npm
+    "command": "npm",
 
-	// the command is a shell script
-	"isShellCommand": true,
+    // the command is a shell script
+    "isShellCommand": true,
 
-	// show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
+    // show the output window only if unrecognized errors occur.
+    "showOutput": "silent",
 
-	// we run the custom script "compile" as defined in package.json
-	"args": ["run", "compile", "--loglevel", "silent"],
+    // we run the custom script "compile" as defined in package.json
+    "args": ["run", "compile", "--loglevel", "silent"],
 
-	// The tsc compiler is started in watching mode
-	"isWatching": true,
+    // The tsc compiler is started in watching mode
+    "isBackground": true,
 
-	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
-	"problemMatcher": "$tsc-watch"
+    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+    "problemMatcher": "$tsc-watch"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Version](http://vsmarketplacebadge.apphb.com/version/joaompinto.asciidoctor-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=joaompinto.asciidoctor-vscode)
-[![Installs](http://vsmarketplacebadge.apphb.com/installs/joaompinto.asciidoctor-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=joaompinto.asciidoctor-vscode)
+[![Version](https://vsmarketplacebadge.apphb.com/version/joaompinto.asciidoctor-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=joaompinto.asciidoctor-vscode)
+[![Installs](https://vsmarketplacebadge.apphb.com/installs/joaompinto.asciidoctor-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=joaompinto.asciidoctor-vscode)
 [![Ratings](https://vsmarketplacebadge.apphb.com/rating/joaompinto.asciidoctor-vscode.svg)](https://vsmarketplacebadge.apphb.com/rating/joaompinto.asciidoctor-vscode.svg)
 
 # AsciiDoc Support

--- a/package.json
+++ b/package.json
@@ -83,11 +83,6 @@
                 "command": "adoc.previewToSide",
                 "title": "Open Preview to the Side",
                 "category": "AsciiDoc"
-            },
-            {
-                "command": "adoc.updateTimer",
-                "title": "Start adoc updateTimer",
-                "category": "AsciiDoc"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,15 @@
                 "title": "Start adoc updateTimer",
                 "category": "AsciiDoc"
             }
-        ]
+        ],
+        "menus": {
+            "editor/title": [
+                {
+                    "command": "adoc.previewToSide",
+                    "when": "resourceLangId == asciidoc"
+                }
+            ]
+        }
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -92,18 +92,19 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "./node_modules/.bin/tsc -p ./",
-        "compile": "./node_modules/.bin/tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
         "typescript": "^2.0.3",
         "file-url": "^1.0.1",
+        "vscode": "^1.0.0",
         "@types/node": "^6.0.40",
         "@types/mocha": "^2.2.32"
     },
     "dependencies": {
-        "vscode": "^1.0.0",
         "file-url": "^1.0.1",
         "tmp": "^0.0.29"
     }

--- a/src/AsciiDocProvider.ts
+++ b/src/AsciiDocProvider.ts
@@ -48,7 +48,9 @@ export default class AsciiDocProvider implements TextDocumentContentProvider {
 
     private createAsciiDocHTML(): string | Thenable<string> {
         let editor = window.activeTextEditor;
-        if (!(editor.document.languageId === "asciidoc")) {
+        
+        if ( !editor || !editor.document ||
+            !(editor.document.languageId === "asciidoc")) {
             return this.errorSnippet("Active editor doesn't show an AsciiDoc document - no properties to preview.");
         }
         if (this.needs_rebuild) {
@@ -143,19 +145,7 @@ export default class AsciiDocProvider implements TextDocumentContentProvider {
 export function CreateHTMLWindow(provider, displayColumn: ViewColumn): PromiseLike<void> {
     let previewTitle = `Preview: '${path.basename(window.activeTextEditor.document.fileName)}'`;
     let previewUri = Uri.parse(`adoc-preview://preview/${previewTitle}`);
-
-    // When the active document is changed set the provider for rebuild
-    workspace.onDidChangeTextDocument((e: TextDocumentChangeEvent) => {
-        if (e.document === window.activeTextEditor.document) {
-            provider.set_needs_rebuilds(true);
-        }
-    })
-
-    workspace.onDidSaveTextDocument((e: TextDocument) => {
-        if (e === window.activeTextEditor.document) {
-            provider.update(previewUri);
-        }
-    })
+    
 
     return commands.executeCommand("vscode.previewHtml", previewUri, displayColumn).then((success) => {
     }, (reason) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ import {
 
 import AsciiDocProvider, {
     CreateHTMLWindow,
-    CreateRefreshTimer
+    MakePreviewUri
 } from './AsciiDocProvider';
 
 import * as path from "path";
@@ -43,14 +43,12 @@ export function activate(context: ExtensionContext) {
         workspace.registerTextDocumentContentProvider(AsciiDocProvider.scheme, provider)
     )
 
-    let previewTitle = `Preview: '${path.basename(window.activeTextEditor.document.fileName)}'`;
-    let previewUri = Uri.parse(`adoc-preview://preview/${previewTitle}`)
-
     // When the active document is changed set the provider for rebuild
     //this only occurs after an edit in a document
     workspace.onDidChangeTextDocument((e: TextDocumentChangeEvent) => {
         if (e.document === window.activeTextEditor.document) {
-            provider.set_needs_rebuilds(true);
+            provider.setNeedsRebuild(true);
+           //provider.update(MakePreviewUri(e.document));
         }
     })
 
@@ -58,17 +56,17 @@ export function activate(context: ExtensionContext) {
     // This occurs whenever the selected document changes, its useful to keep the
     window.onDidChangeTextEditorSelection((e: TextEditorSelectionChangeEvent) => {
         if (!!e && !!e.textEditor && (e.textEditor === window.activeTextEditor)) {
-            provider.set_needs_rebuilds(true);
+            provider.setNeedsRebuild(true);
+          //  provider.update(MakePreviewUri(e.textEditor.document));
         }
     })
     
     workspace.onDidSaveTextDocument((e: TextDocument) => {
         if (e === window.activeTextEditor.document) {
-            provider.update(previewUri);
+            provider.update(MakePreviewUri(e));
         }
     })
 
-    CreateRefreshTimer(provider, window.activeTextEditor, previewUri)
     let previewToSide = commands.registerCommand("adoc.previewToSide", () => {
         let displayColumn: ViewColumn;
         switch (window.activeTextEditor.viewColumn) {


### PR DESCRIPTION
Fixes #20, #15 

- Updated to latest vscode plugin config item names
- Prevent undefined error when opening window
- Don't register the workspace listener every time we create a textdocumentprovider
- Add preview to side title menu extension
- Fix the open to left/right functionality to always track a document rather than jump around, ditching activeTextEditor fixes the undefined error as well
- vsce requires https images in the readme now to create a vsix