### PR TITLE
Issue 33 buffer size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.3.6
+    Added symbol view, closes #3
+
+0.3.5
+    ?
+
 0.3.3
     Do not prefix links for local #sections
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Ratings](https://vsmarketplacebadge.apphb.com/rating/joaompinto.asciidoctor-vscode.svg)](https://vsmarketplacebadge.apphb.com/rating/joaompinto.asciidoctor-vscode.svg)
 
 # AsciiDoc Support
-A vscode support extension that provides live preview and syntax highlighting for the AsciiDoc format.
+A vscode support extension that provides live preview, syntax highlighting and symbols for the AsciiDoc format.
 
 An extension to preview AsciiDoc text using the _AsciiDoctor_ publishing tool.
 
@@ -11,6 +11,7 @@ The extension can be activate in two ways
 
 * Toggle Preview - `ctrl+shift+r`
 * Open Preview to the Side - `ctrl+k r`
+* View symbols - go to symbol action - `ctrl+shift+o`, select a heading.
 
 ## How to install
 Open vscode. Press `F1`, search "`ext install`" followed by extension name, in this case: "`ext install asciidoctor-vscode`" without the ">".
@@ -28,7 +29,7 @@ You need to [**install AsciiDoctor**](http://asciidoctor.org/docs/install-toolch
 git clone https://github.com/joaompinto/asciidoctor-vscode
 cd asciidoctor-vscode
 npm install
-sudo npm install -g vsce
+sudo npm install -g vsce typescript
 vsce package
 code --install-extension *.vsix
 ```
@@ -37,3 +38,5 @@ code --install-extension *.vsix
 This extension preview code was based on https://github.com/tht13/RST-vscode/
 
 The AsciiDoc syntax rules are based on https://github.com/asciidoctor/sublimetext-asciidoc/
+
+The symbol view is based on https://github.com/jrieken/md-navigate

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "asciidoctor-vscode",
     "displayName": "AsciiDoc",
-    "description": "Live preview (with AsciiDoctor) and syntax highlighting.",
-    "version": "0.3.3",
+    "description": "Live preview (with AsciiDoctor), syntax highlighting and symbols (outline view)",
+    "version": "0.3.6",
     "publisher": "joaompinto",
     "author": "João Pinto <lamego.pinto@gmail.com>",
     "license": "MIT",
@@ -26,8 +26,7 @@
         "Languages"
     ],
     "activationEvents": [
-        "onCommand:adoc.preview",
-        "onCommand:adoc.previewToSide"
+        "onLanguage:asciidoc"
     ],
     "contributes": {
         "languages": [
@@ -107,8 +106,8 @@
     },
     "devDependencies": {
         "typescript": "^2.0.3",
-        "file-url": "^1.0.1",
         "vscode": "^1.0.0",
+        "mocha": "^2.3.3",
         "@types/node": "^6.0.40",
         "@types/mocha": "^2.2.32"
     },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
                     "type": "number",
                     "default": 1000,
                     "description": "Control how often we will be checking for file changes"
+                },
+                "AsciiDoc.buffer_size_kB": {
+                    "type": "number",
+                    "default": 200,
+                    "description": "Maximum size of output buffer from preview command in kB. Increase if you receive a stdout maxBuffer exceeded error"
                 }
             }
         },

--- a/src/AsciiDocProvider.ts
+++ b/src/AsciiDocProvider.ts
@@ -1,3 +1,4 @@
+
 import {
     workspace,
     window,
@@ -14,6 +15,7 @@ import {
     TextDocument,
     TextEditor
 } from 'vscode';
+
 
 import { exec } from "child_process";
 import * as fs from "fs";
@@ -162,7 +164,7 @@ export function CreateRefreshTimer(provider, editor, previewUri) {
             // This function gets called when the timer goes off.
             TimerCallback(timer, provider, editor, previewUri);
         },
-        // The peroidicity of the timer.
+        // The periodicity of the timer.
         provider.refreshInterval
     );
 }

--- a/src/AsciiDocProvider.ts
+++ b/src/AsciiDocProvider.ts
@@ -128,7 +128,8 @@ export default class AsciiDocProvider implements TextDocumentContentProvider {
             let html_generator = workspace.getConfiguration('AsciiDoc').get('html_generator')
             let cmd = `${html_generator} "${tmpobj.name}"`
             fs.write(tmpobj.fd, text, 0);
-            exec(cmd, (error, stdout, stderr) => {
+            let maxBuff = parseInt(workspace.getConfiguration('AsciiDoc').get('buffer_size_kB'))
+            exec(cmd, {maxBuffer: 1024 * maxBuff}, (error, stdout, stderr) => {
                 tmpobj.removeCallback();
                 if (error) {
                     let errorMessage = [
@@ -143,6 +144,7 @@ export default class AsciiDocProvider implements TextDocumentContentProvider {
                     errorMessage += "<br><br>"
                     errorMessage += "<b>If the asciidoctor binary is not in your PATH, you can set the full path.<br>"
                     errorMessage += "Go to `File -> Preferences -> User settings` and adjust the AsciiDoc.html_generator config option.</b>"
+                    errorMessage += "<br><br><b>Alternatively if you get a stdout maxBuffer exceeded error, Go to `File -> Preferences -> User settings and adjust the AsciiDoc.buffer_size_kB to a larger number (default is 200 kB).</b>"
                     resolve(this.errorSnippet(errorMessage));
                 } else {
                     let result = this.fixLinks(stdout.toString(), doc.fileName);

--- a/src/AsciiDocProvider.ts
+++ b/src/AsciiDocProvider.ts
@@ -123,8 +123,8 @@ export default class AsciiDocProvider implements TextDocumentContentProvider {
             let text = doc.getText();
             let documentPath = path.dirname(doc.fileName);
             let tmpobj = tmp.fileSync({ postfix: '.adoc', dir: documentPath });
-            let html_gerenator = workspace.getConfiguration('AsciiDoc').get('html_generator')
-            let cmd = `${html_gerenator} "${tmpobj.name}"`
+            let html_generator = workspace.getConfiguration('AsciiDoc').get('html_generator')
+            let cmd = `${html_generator} "${tmpobj.name}"`
             fs.write(tmpobj.fd, text, 0);
             exec(cmd, (error, stdout, stderr) => {
                 tmpobj.removeCallback();

--- a/src/AsciiDocProvider.ts
+++ b/src/AsciiDocProvider.ts
@@ -126,7 +126,7 @@ export default class AsciiDocProvider implements TextDocumentContentProvider {
             let html_gerenator = workspace.getConfiguration('AsciiDoc').get('html_generator')
             let cmd = `${html_gerenator} "${tmpobj.name}"`
             fs.write(tmpobj.fd, text, 0);
-            exec(cmd, (error: Error, stdout: Buffer, stderr: Buffer) => {
+            exec(cmd, (error, stdout, stderr) => {
                 tmpobj.removeCallback();
                 if (error) {
                     let errorMessage = [

--- a/src/AsciiDocSymbolProvider.ts
+++ b/src/AsciiDocSymbolProvider.ts
@@ -11,9 +11,8 @@ import {
 
 export default function registerDocumentSymbolProvider(): Disposable {
     
-        const _atxPattern = /^(#){1,6}\s+.+/;
-        const _settext = /^\s*[-~^+]+\s*$/;
-    
+        const _atxPattern = /^(=){1,6}\s+.+/;
+
         return languages.registerDocumentSymbolProvider('asciidoc', {
     
             provideDocumentSymbols(document: TextDocument, token: CancellationToken): SymbolInformation[] {
@@ -24,14 +23,9 @@ export default function registerDocumentSymbolProvider(): Disposable {
                     const {text} = document.lineAt(line);
     
                     if (_atxPattern.test(text)) {
-                        // atx-style, 1-6 hash characters
+                        // atx-style, 1-6 = characters
                         result.push(new SymbolInformation(text, SymbolKind.File, '',
                             new Location(document.uri, new Position(line, 0))));
-    
-                    } else if (line > 0 && _settext.test(text) && document.lineAt(line - 1).text) {
-                        // Settext-style - 'underline'
-                        result.push(new SymbolInformation(document.lineAt(line - 1).text, SymbolKind.File, '',
-                            new Location(document.uri, new Position(line - 1, 0))));
                     }
                 }
     

--- a/src/AsciiDocSymbolProvider.ts
+++ b/src/AsciiDocSymbolProvider.ts
@@ -11,7 +11,7 @@ import {
 
 export default function registerDocumentSymbolProvider(): Disposable {
     
-        const _atxPattern = /^(=){1,6}\s+.+/;
+        const _atxPattern = /^(=|#){1,6}\s+.+/;
 
         return languages.registerDocumentSymbolProvider('asciidoc', {
     

--- a/src/AsciiDocSymbolProvider.ts
+++ b/src/AsciiDocSymbolProvider.ts
@@ -1,0 +1,41 @@
+import {
+    languages,
+    Disposable,
+    CancellationToken,
+    Location,
+    Position,
+    TextDocument,
+    SymbolInformation,
+    SymbolKind
+} from 'vscode';
+
+export default function registerDocumentSymbolProvider(): Disposable {
+    
+        const _atxPattern = /^(#){1,6}\s+.+/;
+        const _settext = /^\s*[-~^+]+\s*$/;
+    
+        return languages.registerDocumentSymbolProvider('asciidoc', {
+    
+            provideDocumentSymbols(document: TextDocument, token: CancellationToken): SymbolInformation[] {
+    
+                const result: SymbolInformation[] = [];
+                const lineCount = Math.min(document.lineCount, 10000);
+                for (let line = 0; line < lineCount; line++) {
+                    const {text} = document.lineAt(line);
+    
+                    if (_atxPattern.test(text)) {
+                        // atx-style, 1-6 hash characters
+                        result.push(new SymbolInformation(text, SymbolKind.File, '',
+                            new Location(document.uri, new Position(line, 0))));
+    
+                    } else if (line > 0 && _settext.test(text) && document.lineAt(line - 1).text) {
+                        // Settext-style - 'underline'
+                        result.push(new SymbolInformation(document.lineAt(line - 1).text, SymbolKind.File, '',
+                            new Location(document.uri, new Position(line - 1, 0))));
+                    }
+                }
+    
+                return result;
+            }
+        });
+    }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,8 @@ import AsciiDocProvider, {
     MakePreviewUri
 } from './AsciiDocProvider';
 
+import registerDocumentSymbolProvider from './AsciiDocSymbolProvider';
+
 import * as path from "path";
 
 export function activate(context: ExtensionContext) {
@@ -85,7 +87,9 @@ export function activate(context: ExtensionContext) {
         return CreateHTMLWindow(provider, window.activeTextEditor.viewColumn);
     })
 
-    context.subscriptions.push(previewToSide, preview, providerRegistrations);
+    const registration = registerDocumentSymbolProvider();
+
+    context.subscriptions.push(previewToSide, preview, providerRegistrations, registration);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
This PR provides a configurable buffer output size for the preview and for rendering failure gives a clue on what to do.

When using large documents, it is easy to get beyond the default 200 kB limit. This is particularly true if one is using the [data-uri](http://asciidoctor.org/docs/user-manual/#managing-images) attribute and embedding (potentially large) images.

Closes #33 

Let me know if you'd prefer this to be rebased.