### PR TITLE
Enable comment toggling via language-configuration.json

### DIFF
--- a/asciidoc-language-configuration.json
+++ b/asciidoc-language-configuration.json
@@ -1,0 +1,6 @@
+{
+    "comments": {
+        "lineComment": "//",
+        "blockComment": [ "////", "////" ]
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "asciidoctor-vscode",
     "displayName": "AsciiDoc",
     "description": "Live preview (with AsciiDoctor), syntax highlighting and symbols (outline view)",
-    "version": "0.3.6",
+    "version": "0.3.8-SNAPSHOT",
     "publisher": "joaompinto",
     "author": "João Pinto <lamego.pinto@gmail.com>",
     "license": "MIT",
@@ -39,7 +39,8 @@
                 "extensions": [
                     ".adoc",
                     ".asciidoc"
-                ]
+                ],
+                "configuration": "./asciidoc-language-configuration.json"
             }
         ],
         "grammars": [


### PR DESCRIPTION
## Overview
Adds support for comment toggling in Visual Studio Code by adding a language-configuration.json file. Comment toggling is one of those things that you don't miss until you don't have it.

I also bumped the version to 0.3.8-SNAPSHOT -- the version in the repo is 0.3.6, but the version on the Marketplace is 0.3.7.

## Testing

I'm running Visual Studio Code v1.19.0.

* Open Code and uninstall the add-on if it is installed. Close Code.
* Copy the repo's contents to `~/.vscode/extensions`
* Manually change the `"name"` and `"displayName"` properties in `package.json`
* Open Code. The add-on should be shown in your Extensions panel.
* Open any `.adoc` file and verify that the Toggle Single Line Comment and Toggle Block Comment commands work (look for them in the palette if you don't know the key bindings)

## Possible issues

Block commenting is kind of janky because it simply inserts `////` before and after the selected text, but I don't think we want to add newlines due to platform-dependence. Still, it's better than nothing, and it works if you highlight blank lines before and after the desired text. Single-line commenting is also a good work around, as always...
