### PR TITLE
Add auto closing brackets

### DIFF
--- a/asciidoc-language-configuration.json
+++ b/asciidoc-language-configuration.json
@@ -2,5 +2,30 @@
     "comments": {
         "lineComment": "//",
         "blockComment": [ "////", "////" ]
-    }
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"]
+    ],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "\"", "close": "\"", "notIn": ["string"] },
+        { "open": "`", "close": "`", "notIn": ["string", "comment"] },
+        { "open": "/**", "close": " */", "notIn": ["string"] },
+        { "open": "////", "close": " ////", "notIn": ["string", "comment"] }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"],
+        ["'", "'"],
+        ["\"", "\""],
+        ["`", "`"]
+    ]
 }


### PR DESCRIPTION
When referencing an attribute such as {revdate}, typing in a {
automatically adds the closing one and places cursor in between.

Also works for the block comment.