### PR TITLE
fixes #27 Please don't use Ctrl-K for previewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ An extension to preview AsciiDoc text using the _AsciiDoctor_ publishing tool.
 
 The extension can be activated in two ways
 
-* Toggle Preview - `ctrl+shift+r`
-* Open Preview to the Side - `ctrl+k r`
+* Toggle Preview - `ctrl+shift+r` (Mac: `cmd+shift+r`)
+* Open Preview to the Side - `ctrl+k shift+r` (Mac: `cmd+k shift+r`)
 * View symbols - go to symbol action - `ctrl+shift+o`, select a heading.
 
 ## How to install

--- a/package.json
+++ b/package.json
@@ -75,12 +75,14 @@
             {
                 "command": "adoc.preview",
                 "key": "ctrl+shift+r",
-                "when": "editorTextFocus"
+                "mac": "shift+cmd+r",
+                "when": "editorTextFocus && editorLangId == asciidoc"
             },
             {
                 "command": "adoc.previewToSide",
-                "key": "ctrl+k r",
-                "when": "editorTextFocus"
+                "key": "ctrl+k shift+r",
+                "mac": "cmd+k shift+r",
+                "when": "editorTextFocus && editorLangId == asciidoc"
             }
         ],
         "commands": [


### PR DESCRIPTION
This changes the keybindings to only be active when editing
asciidoc files, and changse them to use appropriate mappings
for mac, as well as avoiding keybindings that are used elsewhere.

I've verified that these keybindings do not conflict with those
used on my system (a mac) although I've not tested against every
possible extension, and I have not tested Windows.