### PR TITLE
Change working directory to dump and compile untitled documents

### DIFF
--- a/src/AsciiDocProvider.ts
+++ b/src/AsciiDocProvider.ts
@@ -124,7 +124,7 @@ export default class AsciiDocProvider implements TextDocumentContentProvider {
         return new Promise<string>((resolve, reject) => {
             let text = doc.getText();
             let documentPath = path.dirname(doc.fileName);
-            let tmpobj = tmp.fileSync({ postfix: '.adoc', dir: documentPath });
+            let tmpobj = doc.isUntitled ? tmp.fileSync({ postfix: '.adoc' }) : tmp.fileSync({ postfix: '.adoc', dir: documentPath });
             let html_generator = workspace.getConfiguration('AsciiDoc').get('html_generator')
             let cmd = `${html_generator} "${tmpobj.name}"`
             fs.write(tmpobj.fd, text, 0);


### PR DESCRIPTION
Fixes #40 

Change the working directory where the content of the document is dumped to the default temporary directory when the document has not been saved.
The document tried to be dumped in the directory of VSCode, which the others than the administrator have no permission to write, in Windows, so you cannot preview your documents until you save them.