### PR TITLE
.ad file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
                 ],
                 "extensions": [
                     ".adoc",
+                    ".ad",
                     ".asciidoc"
                 ],
                 "configuration": "./asciidoc-language-configuration.json"


### PR DESCRIPTION
I use this short file extension for included partials and some automated processes, it's very usefull to have. For example when you want to pull some CSS with Sass only if you have that file included you can call that file *my-file.ad.scss* and be certain that it belongs to *my-file.ad* and not anything else.

Tools like https://addons.mozilla.org/en-US/firefox/addon/asciidoctorjs-live-preview/ have it listed, but not the other short one- .asc which is actively discouraged since gpg signature files have the same extension.