### PR TITLE
Add option to use default stylesheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
                     "default": "${currentFileDir}",
                     "description": "The base path of image url.You can use variable ${currentFileDir} and ${projectRoot}. ${currentFileDir} will be replace by the path of directory that contain current editing file. ${projectRoot} will be replace by path of the project opened in vscode. If you set basePath to empty String, it will insert absolute path to file."
                 },
+                "AsciiDoc.useDefaultStylesheet": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use the default asciidoctor stylesheet."
+                },
                 "AsciiDoc.forceUnixStyleSeparator": {
                     "type": "boolean",
                     "default": true,

--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -58,11 +58,12 @@ export class AsciiDocParser {
     private async convert_using_javascript() {
         return new Promise<string>(resolve => {
             const contains_stylesheet = !isNullOrUndefined(this.text.match(new RegExp("^\\s*:stylesheet:", "img")));
+            const use_default_stylesheet = vscode.workspace.getConfiguration('AsciiDoc').get('useDefaultStylesheet', false);
             const documentPath = path.dirname(this.filename);
             const ext_path = vscode.extensions.getExtension('joaompinto.asciidoctor-vscode').extensionPath;
             const stylesdir = path.join(ext_path, 'assets')
             var attributes = {};
-            if (contains_stylesheet)
+            if (contains_stylesheet || use_default_stylesheet)
                 attributes = { 'copycss': true }
             else
                 attributes = { 'copycss': true, 'stylesdir': stylesdir, 'stylesheet': 'asciidoctor.css' }


### PR DESCRIPTION
Add a new setting `useDefaultStylesheet` which, if enabled, renders using the default Asciidoctor stylesheet instead of the extension's default one.

This is compatible with the focus-following and highlighting behaviour.

Resolves #98 